### PR TITLE
Ci/coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,29 @@
+# A separated coverage workflow avoid using `pull_request_target` event when running tests
+
+name: Coverage
+on:
+  workflow_run:
+    workflows:
+      - Test
+    types:
+      - completed
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Download Artifact coverage
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: test.yml
+          run_id: ${{ github.event.workflow_run.id }}
+          name: docs-zip
+
+      - name: Upload coverage
+        uses: codacy/codacy-coverage-reporter-action@master
+        with:
+          project-token: ${{ secrets.CODACY_TOKEN }}
+          coverage-reports: coverage.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,7 +120,7 @@ jobs:
         run: export PYTHONPATH=$PYTHONPATH:$(pwd)/turbulette && make testcov-xml
 
       - name: Upload coverage artifact
-      - uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v2
         if: matrix.python-version == '3.9'
         with:
           name: coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,10 @@
-# Adapted from https://github.com/python-gino/gino/blob/master/.github/workflows/test.yml
-
 name: Test
 
 on:
   push:
+    branches:
+      - "main"
+      - "ci/*"
   pull_request:
     types: [opened, synchronize]
 
@@ -118,9 +119,9 @@ jobs:
           TURBULETTE_SETTINGS_MODULE: tests.settings
         run: export PYTHONPATH=$PYTHONPATH:$(pwd)/turbulette && make testcov-xml
 
-      - name: Upload coverage
+      - name: Upload coverage artifact
+      - uses: actions/upload-artifact@v2
         if: matrix.python-version == '3.9'
-        uses: codacy/codacy-coverage-reporter-action@master
         with:
-          project-token: ${{ secrets.CODACY_TOKEN }}
-          coverage-reports: coverage.xml
+          name: coverage
+          path: ./coverage.xml


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Change Summary**

Add a coverage workflow to avoid using `pull_request_target` event during tests

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] Tests pass on CI and coverage remains at 100%
- [x] Documentation reflects the changes where applicable

**Other information:**
